### PR TITLE
fix: Update Jar task for Gradle 5.1+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,9 +132,13 @@ afterEvaluate { project ->
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
+        if (GradleVersion.current() >= GradleVersion.version('5.1')) {
+            archiveClassifier = 'sources'
+        } else {
+            classifier = 'sources'
+        }
     }
 
     android.libraryVariants.all { variant ->


### PR DESCRIPTION
从Gradle 7.0开始，classifier属性被弃用，并在Gradle 8.0中完全被删除。取而代之的是archiveClassifier属性。

*相关文档*
[5.1开始支持archiveClassifier](https://docs.gradle.org/5.1/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:archiveClassifier)
[Gradle 8.0 移除Classifier](https://docs.gradle.org/current/userguide/upgrading_version_7.html#abstractarchivetask_api_cleanup)
[Gradle 7.0 提到移除Classifier](https://docs.gradle.org/7.0/release-notes.html#features-removed-in-7.0)